### PR TITLE
Feat: 일일 수분 섭취량 및 목표 수분량 조회 API 추가

### DIFF
--- a/src/main/java/team/gachi/watery/drink/controller/DrinkController.java
+++ b/src/main/java/team/gachi/watery/drink/controller/DrinkController.java
@@ -23,7 +23,6 @@ import java.time.LocalDate;
 
 @Tag(name = "음료", description = "음료 관련 API")
 @RequiredArgsConstructor
-@Valid
 @RestController("/api/v1/drinks")
 public class DrinkController {
     private final DrinkService drinkService;
@@ -34,6 +33,7 @@ public class DrinkController {
             @Parameter(hidden = true)
             Principal principal,
 
+            @Valid
             @RequestBody
             AddDrinkRequestDto request
     ) {

--- a/src/main/java/team/gachi/watery/drink/controller/DrinkController.java
+++ b/src/main/java/team/gachi/watery/drink/controller/DrinkController.java
@@ -3,21 +3,27 @@ package team.gachi.watery.drink.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import team.gachi.watery.drink.dto.AddDrinkRequestDto;
 import team.gachi.watery.drink.dto.AddDrinkResponseDto;
 import team.gachi.watery.drink.dto.DrinksResponseDto;
+import team.gachi.watery.drink.dto.HydrationAmountResponseDto;
 import team.gachi.watery.drink.service.DrinkService;
 import team.gachi.watery.dto.WateryResponse;
 
 import java.security.Principal;
+import java.time.LocalDate;
 
 @Tag(name = "음료", description = "음료 관련 API")
 @RequiredArgsConstructor
+@Valid
 @RestController("/api/v1/drinks")
 public class DrinkController {
     private final DrinkService drinkService;
@@ -40,9 +46,33 @@ public class DrinkController {
     @GetMapping
     public WateryResponse<DrinksResponseDto> getDrinks(
             @Parameter(hidden = true)
-            Principal principal
+            Principal principal,
+
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            @Parameter(description = "기준 날짜 (없으면 당일 기준)", example = "2025-07-01")
+            LocalDate baseDate
     ) {
-        DrinksResponseDto response = drinkService.getDrinks(Long.valueOf(principal.getName()));
+        DrinksResponseDto response = drinkService.getDrinks(Long.valueOf(principal.getName()), baseDate);
+
+        return WateryResponse.of(response);
+    }
+
+    @Operation(
+            summary = "일일 수분 섭취량 및 목표 수분량 조회",
+            description = "사용자의 일일 수분 섭취량과 일일 목표 수분 섭취량을 조회합니다."
+    )
+    @GetMapping("/amount")
+    public WateryResponse<HydrationAmountResponseDto> getHydrationAmount(
+            @Parameter(hidden = true)
+            Principal principal,
+
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            @Parameter(description = "기준 날짜 (없으면 당일 기준)", example = "2025-07-01")
+            LocalDate baseDate
+    ) {
+        HydrationAmountResponseDto response = drinkService.getHydrationAmount(Long.valueOf(principal.getName()), baseDate);
 
         return WateryResponse.of(response);
     }

--- a/src/main/java/team/gachi/watery/drink/domain/DrinkHistory.java
+++ b/src/main/java/team/gachi/watery/drink/domain/DrinkHistory.java
@@ -36,7 +36,7 @@ public class DrinkHistory extends BaseEntity {
 
     @Column(nullable = false)
     @Comment("섭취 시간")
-    private LocalDateTime drinkAT;
+    private LocalDateTime drinkAt;
 
     /**
      * @return 등록된 음료가 아닌 수동 입력 음료인지 여부

--- a/src/main/java/team/gachi/watery/drink/dto/ColorTemplateDto.java
+++ b/src/main/java/team/gachi/watery/drink/dto/ColorTemplateDto.java
@@ -1,5 +1,6 @@
 package team.gachi.watery.drink.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Builder;
 import team.gachi.watery.drink.domain.ColorTemplate;
@@ -9,7 +10,9 @@ import java.util.List;
 
 @Builder(access = AccessLevel.PRIVATE)
 public record ColorTemplateDto(
+        @Schema(description = "색상 템플릿 ID", example = "1")
         Long colorTemplateId,
+        @Schema(description = "색상 목록", example = "[\"#FF5733\", \"#33FF57\", \"#3357FF\"]")
         List<String> colors
 ) {
     public static ColorTemplateDto of(ColorTemplate colorTemplate) {

--- a/src/main/java/team/gachi/watery/drink/dto/DrinkDto.java
+++ b/src/main/java/team/gachi/watery/drink/dto/DrinkDto.java
@@ -1,20 +1,28 @@
 package team.gachi.watery.drink.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Builder;
 import team.gachi.watery.drink.domain.Drink;
 
 @Builder(access = AccessLevel.PRIVATE)
 public record DrinkDto(
+        @Schema(description = "음료 ID", example = "1")
         Long id,
+        @Schema(description = "음료 이름", example = "물")
         String name,
+        @Schema(description = "총 섭취량", example = "500")
+        int totalAmount,
+        @Schema(description = "일일 수분 섭취 목표 포함 여부", example = "true")
         boolean includesDailyHydrationGoal,
+        @Schema(description = "색상 템플릿 정보")
         ColorTemplateDto colorTemplate
 ) {
-    public static DrinkDto of(Drink drink) {
+    public static DrinkDto of(Drink drink, int totalAmount) {
         return DrinkDto.builder()
                 .id(drink.getId())
                 .name(drink.getName())
+                .totalAmount(totalAmount)
                 .includesDailyHydrationGoal(drink.getIncludesDailyHydrationGoal())
                 .colorTemplate(ColorTemplateDto.of(drink.getColorTemplate()))
                 .build();

--- a/src/main/java/team/gachi/watery/drink/dto/DrinksResponseDto.java
+++ b/src/main/java/team/gachi/watery/drink/dto/DrinksResponseDto.java
@@ -1,5 +1,6 @@
 package team.gachi.watery.drink.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Builder;
 
@@ -7,12 +8,11 @@ import java.util.List;
 
 @Builder(access = AccessLevel.PRIVATE)
 public record DrinksResponseDto(
-        int dailyHydrationGoal,
+        @Schema(description = "음료 목록")
         List<DrinkDto> drinks
 ) {
-    public static DrinksResponseDto of(int dailyHydrationGoal, List<DrinkDto> drinks) {
+    public static DrinksResponseDto of(List<DrinkDto> drinks) {
         return DrinksResponseDto.builder()
-                .dailyHydrationGoal(dailyHydrationGoal)
                 .drinks(drinks)
                 .build();
     }

--- a/src/main/java/team/gachi/watery/drink/dto/HydrationAmountResponseDto.java
+++ b/src/main/java/team/gachi/watery/drink/dto/HydrationAmountResponseDto.java
@@ -1,0 +1,21 @@
+package team.gachi.watery.drink.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record HydrationAmountResponseDto(
+        @Schema(description = "일일 수분 섭취 목표", example = "2000")
+        int dailyHydrationGoal,
+        @Schema(description = "총 섭취량", example = "500")
+        int totalHydrationAmount
+) {
+    public static HydrationAmountResponseDto of(int dailyHydrationGoal, int totalHydrationAmount) {
+        return HydrationAmountResponseDto.builder()
+                .dailyHydrationGoal(dailyHydrationGoal)
+                .totalHydrationAmount(totalHydrationAmount)
+                .build();
+    }
+}
+

--- a/src/main/java/team/gachi/watery/drink/repository/DrinkCustomRepository.java
+++ b/src/main/java/team/gachi/watery/drink/repository/DrinkCustomRepository.java
@@ -1,0 +1,11 @@
+package team.gachi.watery.drink.repository;
+
+
+import team.gachi.watery.common.Status;
+import team.gachi.watery.drink.domain.Drink;
+
+import java.util.List;
+
+public interface DrinkCustomRepository {
+    List<Drink> findAllBy(Long userId, Status status);
+}

--- a/src/main/java/team/gachi/watery/drink/repository/DrinkHistoryCustomRepository.java
+++ b/src/main/java/team/gachi/watery/drink/repository/DrinkHistoryCustomRepository.java
@@ -1,0 +1,10 @@
+package team.gachi.watery.drink.repository;
+
+
+import java.time.LocalDate;
+
+public interface DrinkHistoryCustomRepository {
+    int sumTotalDrinkAmountBy(Long drinkId, Long userId, LocalDate baseDate);
+
+    int sumTotalHydrationAmount(Long userId, LocalDate baseDate);
+}

--- a/src/main/java/team/gachi/watery/drink/repository/DrinkHistoryRepository.java
+++ b/src/main/java/team/gachi/watery/drink/repository/DrinkHistoryRepository.java
@@ -5,5 +5,5 @@ import org.springframework.stereotype.Repository;
 import team.gachi.watery.drink.domain.DrinkHistory;
 
 @Repository
-public interface DrinkHistoryRepository extends JpaRepository<DrinkHistory, Long> {
+public interface DrinkHistoryRepository extends JpaRepository<DrinkHistory, Long>, DrinkHistoryCustomRepository {
 }

--- a/src/main/java/team/gachi/watery/drink/repository/DrinkHistoryRepositoryImpl.java
+++ b/src/main/java/team/gachi/watery/drink/repository/DrinkHistoryRepositoryImpl.java
@@ -1,0 +1,53 @@
+package team.gachi.watery.drink.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import team.gachi.watery.drink.domain.DrinkHistory;
+import team.gachi.watery.drink.domain.QDrink;
+import team.gachi.watery.drink.domain.QDrinkHistory;
+
+import java.time.LocalDate;
+
+@Repository
+@RequiredArgsConstructor
+public class DrinkHistoryRepositoryImpl implements DrinkHistoryCustomRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public int sumTotalDrinkAmountBy(Long drinkId, Long userId, LocalDate baseDate) {
+        QDrinkHistory drinkHistory = QDrinkHistory.drinkHistory;
+
+        Integer totalAmount = queryFactory
+                .select(drinkHistory.amount.sum())
+                .from(drinkHistory)
+                .where(
+                        drinkHistory.drink.id.eq(drinkId),
+                        drinkHistory.user.id.eq(userId),
+                        drinkHistory.drinkAt.between(baseDate.atStartOfDay(), baseDate.atTime(23, 59, 59))
+                )
+                .fetchOne();
+
+        return totalAmount != null ? totalAmount : 0;
+    }
+
+    @Override
+    public int sumTotalHydrationAmount(Long userId, LocalDate baseDate) {
+        QDrinkHistory drinkHistory = QDrinkHistory.drinkHistory;
+        QDrink drink = QDrink.drink;
+
+        Integer totalAmount = queryFactory
+                .select(drinkHistory.amount.sum())
+                .from(drinkHistory)
+                .innerJoin(drink)
+                .on(drink.id.eq(drinkHistory.drink.id)
+                        .and(drink.includesDailyHydrationGoal))
+                .where(
+                        drinkHistory.user.id.eq(userId),
+                        drinkHistory.drinkAt.between(baseDate.atStartOfDay(), baseDate.atTime(23, 59, 59))
+                )
+                .fetchOne();
+
+        return totalAmount != null ? totalAmount : 0;
+    }
+}

--- a/src/main/java/team/gachi/watery/drink/repository/DrinkHistoryRepositoryImpl.java
+++ b/src/main/java/team/gachi/watery/drink/repository/DrinkHistoryRepositoryImpl.java
@@ -24,7 +24,8 @@ public class DrinkHistoryRepositoryImpl implements DrinkHistoryCustomRepository 
                 .where(
                         drinkHistory.drink.id.eq(drinkId),
                         drinkHistory.user.id.eq(userId),
-                        drinkHistory.drinkAt.between(baseDate.atStartOfDay(), baseDate.atTime(23, 59, 59))
+                        drinkHistory.drinkAt.goe(baseDate.atStartOfDay()),
+                        drinkHistory.drinkAt.lt(baseDate.plusDays(1).atStartOfDay())
                 )
                 .fetchOne();
 
@@ -44,7 +45,8 @@ public class DrinkHistoryRepositoryImpl implements DrinkHistoryCustomRepository 
                         .and(drink.includesDailyHydrationGoal))
                 .where(
                         drinkHistory.user.id.eq(userId),
-                        drinkHistory.drinkAt.between(baseDate.atStartOfDay(), baseDate.atTime(23, 59, 59))
+                        drinkHistory.drinkAt.goe(baseDate.atStartOfDay()),
+                        drinkHistory.drinkAt.lt(baseDate.plusDays(1).atStartOfDay())
                 )
                 .fetchOne();
 

--- a/src/main/java/team/gachi/watery/drink/repository/DrinkRepository.java
+++ b/src/main/java/team/gachi/watery/drink/repository/DrinkRepository.java
@@ -7,8 +7,6 @@ import team.gachi.watery.drink.domain.Drink;
 import java.util.List;
 
 @Repository
-public interface DrinkRepository extends JpaRepository<Drink, Long> {
-    List<Drink> findAllByUserId(Long userId);
-
+public interface DrinkRepository extends JpaRepository<Drink, Long>, DrinkCustomRepository {
     boolean existsByUserIdAndName(Long userId, String name);
 }

--- a/src/main/java/team/gachi/watery/drink/repository/DrinkRepositoryImpl.java
+++ b/src/main/java/team/gachi/watery/drink/repository/DrinkRepositoryImpl.java
@@ -1,0 +1,32 @@
+package team.gachi.watery.drink.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import team.gachi.watery.common.Status;
+import team.gachi.watery.drink.domain.Drink;
+import team.gachi.watery.drink.domain.QDrink;
+import team.gachi.watery.drink.domain.QDrinkHistory;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class DrinkRepositoryImpl implements DrinkCustomRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Drink> findAllBy(Long userId, Status status) {
+        QDrink drink = QDrink.drink;
+
+        return queryFactory
+                .select(drink)
+                .from(drink)
+                .where(
+                        drink.user.id.eq(userId),
+                        drink.status.eq(status)
+                )
+                .fetch();
+    }
+}


### PR DESCRIPTION
## 주요 변경 사항
- 일일 수분 섭취량 및 목표 조회 API(/api/v1/drinks/amount) 추가
- DrinkHistory 컬럼명(drinkAT → drinkAt) 오타 수정
- DrinkHistoryCustomRepository 및 구현체 추가
- 기존 음료 조회 응답에서 DailyHydrationGoal 제거